### PR TITLE
Fix user loading error by ensuring table creation

### DIFF
--- a/CRM/DatabaseConnection.cs
+++ b/CRM/DatabaseConnection.cs
@@ -34,5 +34,38 @@ namespace CRM
                 return false;
             }
         }
+
+        /// <summary>
+        /// Ensures the required tables exist in the database. If they do not,
+        /// they will be created with the expected schema.
+        /// </summary>
+        public void EnsureTables()
+        {
+            try
+            {
+                using var connection = GetConnection();
+                connection.Open();
+
+                using var command = connection.CreateCommand();
+                command.CommandText = @"CREATE TABLE IF NOT EXISTS Users (
+                        Id INT AUTO_INCREMENT PRIMARY KEY,
+                        Name VARCHAR(255) NOT NULL,
+                        Email VARCHAR(255) NOT NULL
+                    );";
+                command.ExecuteNonQuery();
+
+                command.CommandText = @"CREATE TABLE IF NOT EXISTS Clients (
+                        Id INT AUTO_INCREMENT PRIMARY KEY,
+                        Name VARCHAR(255) NOT NULL,
+                        Email VARCHAR(255) NOT NULL
+                    );";
+                command.ExecuteNonQuery();
+            }
+            catch (Exception ex)
+            {
+                // Log to console but do not crash the application during startup
+                Console.WriteLine($"Database initialization failed: {ex.Message}");
+            }
+        }
     }
 }

--- a/CRM/MauiProgram.cs
+++ b/CRM/MauiProgram.cs
@@ -33,6 +33,12 @@ public static class MauiProgram
         builder.Logging.AddDebug();
 #endif
 
-        return builder.Build();
+        var app = builder.Build();
+
+        // Ensure database schema exists on startup
+        var dbInitializer = new CRM.DatabaseConnection();
+        dbInitializer.EnsureTables();
+
+        return app;
     }
 }

--- a/CRM/README.md
+++ b/CRM/README.md
@@ -20,6 +20,12 @@ A cross-platform Customer Relationship Management system built with .NET MAUI an
 3. Run `dotnet build`
 4. Run the application
 
+### Database setup
+The application uses MySQL. Update the connection string in
+`MauiProgram.cs` with your database credentials. On the first run the
+application will automatically create the required tables (`Users` and
+`Clients`) if they do not exist.
+
 ## Technologies Used
 - .NET MAUI
 - Blazor


### PR DESCRIPTION
## Summary
- automatically create required tables on startup
- wire up `DatabaseConnection.EnsureTables` in `MauiProgram`
- document the new automatic database setup in the README

## Testing
- `dotnet build CRM/CRM.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ff4d6af08832bab8bf610ac0b29c0